### PR TITLE
feat: Add ability to remove profile picture

### DIFF
--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -37,6 +37,10 @@ export default {
         h += `<div style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
             h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
             h += `</div>`;
+            // Add remove button if user has a custom profile picture
+            if (window.user?.profile?.picture) {
+                h += `<button class="button button-danger remove-profile-picture" style="margin-top: 10px; font-size: 12px;">${i18n('remove_profile_picture')}</button>`;
+            }
         h += `</div>`;
 
         // change password button
@@ -150,6 +154,26 @@ export default {
             });    
         })
 
+        $el_window.find('.remove-profile-picture').on('click', async function (e) {
+            e.preventDefault();
+            
+            // Confirm the action
+            if (!confirm(i18n('confirm_remove_profile_picture'))) {
+                return;
+            }
+            
+            // Remove the profile picture by setting it to null
+            update_profile(window.user.username, {picture: null});
+            
+            // Update the UI immediately
+            $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(window.icons['profile.svg']) + ')');
+            $('.profile-image').css('background-image', 'url(' + html_encode(window.icons['profile.svg']) + ')');
+            $('.profile-image').removeClass('profile-image-has-picture');
+            
+            // Remove the remove button since there's no custom picture anymore
+            $el_window.find('.remove-profile-picture').remove();
+        })
+
         $el_window.on('file_opened', async function(e){
             let selected_file = Array.isArray(e.detail) ? e.detail[0] : e.detail;
             // set profile picture
@@ -172,6 +196,33 @@ export default {
                     $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(base64data) + ')');
                     $('.profile-image').css('background-image', 'url(' + html_encode(base64data) + ')');
                     $('.profile-image').addClass('profile-image-has-picture');
+                    
+                    // Add remove button if it doesn't exist
+                    if (!$el_window.find('.remove-profile-picture').length) {
+                        $el_window.find('.profile-picture').parent().append(`<button class="button button-danger remove-profile-picture" style="margin-top: 10px; font-size: 12px;">${i18n('remove_profile_picture')}</button>`);
+                        
+                        // Re-bind the event handler for the new button
+                        $el_window.find('.remove-profile-picture').on('click', async function (e) {
+                            e.preventDefault();
+                            
+                            // Confirm the action
+                            if (!confirm(i18n('confirm_remove_profile_picture'))) {
+                                return;
+                            }
+                            
+                            // Remove the profile picture by setting it to null
+                            update_profile(window.user.username, {picture: null});
+                            
+                            // Update the UI immediately
+                            $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(window.icons['profile.svg']) + ')');
+                            $('.profile-image').css('background-image', 'url(' + html_encode(window.icons['profile.svg']) + ')');
+                            $('.profile-image').removeClass('profile-image-has-picture');
+                            
+                            // Remove the remove button since there's no custom picture anymore
+                            $el_window.find('.remove-profile-picture').remove();
+                        });
+                    }
+                    
                     // update profile picture
                     update_profile(window.user.username, {picture: base64data})
                 }

--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -1138,7 +1138,7 @@ async function UIDesktop(options){
 
         // user options menu
         ht += `<div class="toolbar-btn user-options-menu-btn profile-pic" style="display:block;">`;
-            ht += `<div class="profile-image ${window.user?.profile?.picture && 'profile-image-has-picture'}" style="border-radius: 50%; background-image:url(${window.user?.profile?.picture || window.icons['profile.svg']}); box-sizing: border-box; width: 17px !important; height: 17px !important; background-size: contain; background-repeat: no-repeat; background-position: center; background-position: center; background-size: cover;"></div>`;
+            ht += `<div class="profile-image ${window.user?.profile?.picture && 'profile-image-has-picture'}" style="border-radius: 50%; background-image:url(${window.user?.profile?.picture || window.icons['profile.svg']}); box-sizing: border-box; width: 17px !important; height: 17px !important; background-size: cover; background-repeat: no-repeat; background-position: center;"></div>`;
         ht += `</div>`;
     ht += `</div>`;
 

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -238,6 +238,8 @@ const en = {
         refresh: 'Refresh',
         release_address_confirmation: `Are you sure you want to release this address?`,
         remove_from_taskbar:'Remove from Taskbar',
+        remove_profile_picture: 'Remove Profile Picture',
+        confirm_remove_profile_picture: 'Are you sure you want to remove your profile picture?',
         rename: 'Rename',
         repeat: 'Repeat',
         replace: 'Replace',


### PR DESCRIPTION
Description of Pull Request:

- Adds 'Remove Profile Picture' button in account settings
- Button appears when user has custom profile picture
- Includes confirmation dialog to prevent accidental removal
- Updates both settings page and desktop toolbar immediately
- Fixes circular profile picture display in desktop toolbar
- Adds internationalization strings for new UI elements

Resolves Issue #1  

Before Screenshot
<img width="1710" height="931" alt="Screenshot 2025-10-12 at 10 59 38 PM" src="https://github.com/user-attachments/assets/0589b3c7-1b84-49a4-97fd-fda668e15c3d" />

After Screenshot
<img width="1710" height="931" alt="Screenshot 2025-10-12 at 11 01 02 PM" src="https://github.com/user-attachments/assets/247ade61-8f34-4a01-a05e-15d2fd773c3a" />


Video Demo and Code Walkthrough: https://cap.link/hk9v8ah7ew3vj1d
