### PR TITLE
Fix/sidebar text lightness readability clean

### DIFF
--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -409,6 +409,11 @@ input[type=text]:focus, input[type=password]:focus, input[type=email]:focus, sel
     opacity: 0.7
 }
 
+/* Hide all desktop icons when this class is applied to desktop container */
+.desktop.desktop-hide-icons > .item {
+    display: none;
+}
+
 .item-container-list .item {
     height: initial;
     width: max-content;
@@ -1218,7 +1223,7 @@ span.header-sort-icon img {
     margin: 0;
     font-weight: bold;
     font-size: 13px;
-    color: #8f96a3;
+    color: var(--window-sidebar-color);
     text-shadow: 1px 1px rgb(247 247 247 / 15%);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -1243,7 +1248,7 @@ span.header-sort-icon img {
     margin-top: 2px;
     padding: 4px;
     border-radius: 3px;
-    color: #444444;
+    color: var(--window-sidebar-color);
     font-size: 13px;
     cursor: pointer;
     transition: 0.15s background-color;
@@ -1256,6 +1261,7 @@ span.header-sort-icon img {
 
 .window-sidebar-item-active, .window-sidebar-item-drag-active, .window-sidebar-item-active:hover {
     background-color: #fefeff;
+    color: #373e44;
 }
 
 .window-sidebar-item-placeholder {

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -409,10 +409,6 @@ input[type=text]:focus, input[type=password]:focus, input[type=email]:focus, sel
     opacity: 0.7
 }
 
-/* Hide all desktop icons when this class is applied to desktop container */
-.desktop.desktop-hide-icons > .item {
-    display: none;
-}
 
 .item-container-list .item {
     height: initial;


### PR DESCRIPTION
Description of Pull Request:

Changes:

- Replace hardcoded colors in .window-sidebar-title and .window-sidebar-item with var(--window-sidebar-color)
- Add explicit dark color for .window-sidebar-item-active to ensure contrast on white selection background
- Text now automatically adapts: dark on light themes, white on dark themes
- Result: Sidebar text remains readable across all theme lightness values

Fixes Issue #5 


Before Screenshot
<img width="1677" height="768" alt="Screenshot 2025-10-20 at 5 27 49 PM" src="https://github.com/user-attachments/assets/cc0e275d-2975-4d63-aebd-fb3e7074ccbe" />

After Screenshot
<img width="1669" height="872" alt="Screenshot 2025-10-20 at 5 28 42 PM" src="https://github.com/user-attachments/assets/f2f29e93-7f4f-4e7d-b04e-1eb55a453128" />


Video Demo and Code Walkthrough: https://www.loom.com/share/b405c0200a80496baf507fa441eff6e3?sid=877e9db4-a07b-4e28-a8dd-86f5ed5b34cd 