### PR TITLE
feat: implement dynamic auto-hide toolbar

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -42,6 +42,7 @@ import UIWindowWelcome from "./UIWindowWelcome.js"
 import launch_app from "../helpers/launch_app.js"
 import item_icon from "../helpers/item_icon.js"
 import UIWindowSearch from "./UIWindowSearch.js"
+import update_mouse_position from "../helpers/update_mouse_position.js"
 
 async function UIDesktop(options){
     let h = '';
@@ -1894,7 +1895,8 @@ window.init_toolbar_auto_hide = ()=>{
     window.reset_toolbar_hide_timer();
     
     // Reset timer on any mouse movement
-    $(document).on('mousemove.toolbar_autohide', function(){
+    $(document).on('mousemove.toolbar_autohide', function(event){
+        update_mouse_position(event.clientX, event.clientY);
         window.reset_toolbar_hide_timer();
     });
     

--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -1151,6 +1151,9 @@ async function UIDesktop(options){
     // adjust window container to take into account the toolbar height
     $('.window-container').css('top', window.toolbar_height);
 
+    // Initialize toolbar auto-hide behavior
+    window.init_toolbar_auto_hide();
+
     // track: checkpoint
     //-----------------------------
     // GUI is ready to launch apps!
@@ -1821,6 +1824,92 @@ window.reset_window_size_and_position = (el_window)=>{
         'border-radius': window.window_border_radius,
         top: 'calc(50% - 190px)',
         left: 'calc(50% - 340px)',
+    });
+}
+
+/**
+ * Hides the toolbar with animation
+ */
+window.hide_toolbar = ()=>{
+    if(!window.toolbar_auto_hide_enabled || window.toolbar_is_hidden)
+        return;
+    
+    $('.toolbar').addClass('toolbar-hidden');
+    window.toolbar_is_hidden = true;
+}
+
+/**
+ * Shows the toolbar with animation
+ */
+window.show_toolbar = ()=>{
+    if(!window.toolbar_auto_hide_enabled)
+        return;
+    
+    $('.toolbar').removeClass('toolbar-hidden');
+    window.toolbar_is_hidden = false;
+}
+
+/**
+ * Resets the toolbar auto-hide timer
+ */
+window.reset_toolbar_hide_timer = ()=>{
+    if(!window.toolbar_auto_hide_enabled)
+        return;
+    
+    // Clear existing timeout
+    if(window.toolbar_hide_timeout){
+        clearTimeout(window.toolbar_hide_timeout);
+        window.toolbar_hide_timeout = null;
+    }
+    
+    // Show toolbar if mouse is near it
+    if(window.mouse_near_toolbar){
+        window.show_toolbar();
+        return;
+    }
+    
+    // If toolbar is hidden and mouse is not near it, keep it hidden
+    if(window.toolbar_is_hidden && !window.mouse_near_toolbar){
+        return;
+    }
+    
+    // Show toolbar and set timer to hide it
+    window.show_toolbar();
+    window.toolbar_hide_timeout = setTimeout(()=>{
+        // Only hide if mouse is not near toolbar
+        if(!window.mouse_near_toolbar){
+            window.hide_toolbar();
+        }
+    }, window.toolbar_hide_delay);
+}
+
+/**
+ * Initializes toolbar auto-hide behavior
+ */
+window.init_toolbar_auto_hide = ()=>{
+    if(!window.toolbar_auto_hide_enabled)
+        return;
+    
+    // Start the initial hide timer
+    window.reset_toolbar_hide_timer();
+    
+    // Reset timer on any mouse movement
+    $(document).on('mousemove.toolbar_autohide', function(){
+        window.reset_toolbar_hide_timer();
+    });
+    
+    // Keep toolbar visible when hovering over it
+    $('.toolbar').on('mouseenter', function(){
+        window.show_toolbar();
+        if(window.toolbar_hide_timeout){
+            clearTimeout(window.toolbar_hide_timeout);
+            window.toolbar_hide_timeout = null;
+        }
+    });
+    
+    // Restart hide timer when leaving toolbar
+    $('.toolbar').on('mouseleave', function(){
+        window.reset_toolbar_hide_timer();
     });
 }
   

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -1740,7 +1740,9 @@ label {
     width: 100%;
     background-color: #00000040;
     height: 30px;
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
     z-index: 999999;
     box-sizing: border-box;
     display: flex;
@@ -1748,7 +1750,16 @@ label {
     justify-content: flex-end;
     align-content: center;
     flex-wrap: wrap;
-    padding-right: 10px
+    padding-right: 10px;
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    transform: translateY(0);
+    opacity: 1;
+}
+
+.toolbar.toolbar-hidden {
+    transform: translateY(-100%);
+    opacity: 0;
+    pointer-events: none;
 }
 
 .show-desktop-btn {

--- a/src/gui/src/globals.js
+++ b/src/gui/src/globals.js
@@ -106,6 +106,14 @@ window.window_stack = []
 window.toolbar_height = 30;
 window.default_taskbar_height = 50;
 window.taskbar_height = window.default_taskbar_height;
+
+// Toolbar auto-hide state
+window.toolbar_auto_hide_enabled = true; // Enable auto-hide by default
+window.toolbar_hide_timeout = null; // Timer for hiding the toolbar
+window.toolbar_is_hidden = false; // Current visibility state
+window.toolbar_hide_delay = 2000; // 2 seconds of inactivity before hiding
+window.toolbar_hover_threshold = 50; // Mouse proximity threshold in pixels
+window.mouse_near_toolbar = false; // Is mouse currently near the toolbar?
 window.upload_progress_hide_delay = 500;
 window.active_uploads = {};
 window.copy_progress_hide_delay = 1000;

--- a/src/gui/src/helpers/update_mouse_position.js
+++ b/src/gui/src/helpers/update_mouse_position.js
@@ -21,6 +21,12 @@ const update_mouse_position = function(x, y){
     window.mouseX = x;
     window.mouseY = y;
 
+    // Detect if mouse is near toolbar (for auto-hide feature)
+    if(window.toolbar_auto_hide_enabled){
+        const near_toolbar = window.mouseY <= window.toolbar_hover_threshold;
+        window.mouse_near_toolbar = near_toolbar;
+    }
+
     // mouse in top-left corner of screen
     if((window.mouseX < 150 && window.mouseY < window.toolbar_height + 20) || (window.mouseX < 20 && window.mouseY < 150))
         window.current_active_snap_zone = 'nw';


### PR DESCRIPTION
Description of Pull Request:

- Add auto-hide behavior that hides toolbar after 2s of inactivity
- Toolbar reappears when mouse moves near top of screen (50px)
- Smooth CSS transitions (0.3s ease-in-out) for animations
- Smart timer management prevents hiding when mouse is near toolbar
- Follows existing Puter patterns for state management and events

Closes #2 

Before

<img width="1665" height="911" alt="Screenshot 2025-10-26 at 12 01 14 AM" src="https://github.com/user-attachments/assets/51c70ef5-ea2c-4479-93c1-630fae3296ec" />

After

<img width="1670" height="914" alt="Screenshot 2025-10-26 at 12 06 25 AM" src="https://github.com/user-attachments/assets/4059954d-fbea-4a34-9c90-93445e7c4548" />


Video Demo and Code Walkthrough:

Part 1: https://www.loom.com/share/c377aa60198d4b61ba4f497e4910e810

Part 2: https://www.loom.com/share/5ad31f451ef64e17985fc172b8bc446d