### PR TITLE
feat(gui): add Hide/Show Desktop Icons toggle (persisted & synced)

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -48,8 +48,6 @@ async function UIDesktop(options){
 
     // Set up the desktop channel for communication between different tabs in the same browser
     window.channel = new BroadcastChannel('puter-desktop-channel');
-    channel.onmessage = function(e){
-    }
 
 
     // Give Camera and Recorder write permissions to Desktop
@@ -736,6 +734,30 @@ async function UIDesktop(options){
 
     window.active_element = el_desktop;
     window.active_item_container = el_desktop;
+    // Listen for preference changes from other tabs/windows and apply hide/show desktop icons
+    if(window.channel){
+        window.channel.onmessage = function(e){
+            try{
+                const data = e.data;
+                if(!data) return;
+                if(data.type === 'user_preferences_changed'){
+                    const delta = data.delta || {};
+                    if(Object.prototype.hasOwnProperty.call(delta, 'hide_desktop_icons')){
+                        const newVal = !!delta.hide_desktop_icons;
+                        if(newVal){
+                            $(el_desktop).find('.item').hide();
+                            $(el_desktop).addClass('desktop-icons-hidden');
+                        }else{
+                            $(el_desktop).find('.item').show();
+                            $(el_desktop).removeClass('desktop-icons-hidden');
+                        }
+                    }
+                }
+            }catch(err){
+                console.warn('Failed to process channel message', err);
+            }
+        }
+    }
     // --------------------------------------------------------
     // Dragster
     // Allow dragging of local files onto desktop.
@@ -944,6 +966,30 @@ async function UIDesktop(options){
                         }
                     },
                     // -------------------------------------------
+                    // Show/Hide Desktop Icons
+                    // -------------------------------------------
+                    {
+                        html: window.user_preferences.hide_desktop_icons ? 'Show Desktop Icons' : 'Hide Desktop Icons',
+                        icon: window.user_preferences.hide_desktop_icons ? '' : '',
+                        onClick: function(){
+                            const newVal = !window.user_preferences.hide_desktop_icons;
+                            // persist preference
+                            window.mutate_user_preferences({
+                                hide_desktop_icons: newVal,
+                            });
+
+                            // apply immediately without changing positions
+                            if(newVal){
+                                // hide item elements but keep them in DOM so positions are preserved
+                                $(el_desktop).find('.item').hide();
+                                $(el_desktop).addClass('desktop-icons-hidden');
+                            }else{
+                                $(el_desktop).find('.item').show();
+                                $(el_desktop).removeClass('desktop-icons-hidden');
+                            }
+                        }
+                    },
+                    // -------------------------------------------
                     // -
                     // -------------------------------------------
                     '-',
@@ -1013,6 +1059,17 @@ async function UIDesktop(options){
     //-------------------------------------------
     if(!window.is_embedded && !window.is_fullpage_mode){
         refresh_item_container(el_desktop, {fadeInItems: true})
+
+        // Apply saved preference to hide desktop icons (preserve positions)
+        try{
+            if(window.user_preferences && window.user_preferences.hide_desktop_icons){
+                // hide item elements but keep them in DOM so positions are preserved
+                $(el_desktop).find('.item').hide();
+                $(el_desktop).addClass('desktop-icons-hidden');
+            }
+        }catch(err){
+            console.warn('Failed to apply hide_desktop_icons preference', err);
+        }
 
         // Show welcome window if user hasn't already seen it and hasn't directly navigated to an app 
         if(!window.url_paths[0]?.toLocaleLowerCase() === 'app' || !window.url_paths[1]){

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -535,6 +535,18 @@ window.mutate_user_preferences = function(user_preferences_delta) {
     }
     // There may be syncing issues across multiple devices
     window.update_user_preferences({ ...window.user_preferences, ...user_preferences_delta });
+
+    // Notify other GUI tabs/windows in the same browser via BroadcastChannel (if available)
+    try{
+        if(window.channel && typeof window.channel.postMessage === 'function'){
+            window.channel.postMessage({
+                type: 'user_preferences_changed',
+                delta: user_preferences_delta,
+            });
+        }
+    }catch(err){
+        // ignore
+    }
 }
 
 window.update_user_preferences = function(user_preferences) {

--- a/src/gui/src/helpers/refresh_item_container.js
+++ b/src/gui/src/helpers/refresh_item_container.js
@@ -228,6 +228,22 @@ const refresh_item_container = function(el_item_container, options){
                 $(el_item_container).attr('data-sort_order')
             );
 
+            // Apply desktop-hide preference: if this container is the desktop and the user prefers icons hidden,
+            // hide item elements while keeping them in the DOM so positions are preserved.
+            try{
+                if($(el_item_container).hasClass('desktop')){
+                    if(window.user_preferences && window.user_preferences.hide_desktop_icons){
+                        $(el_item_container).find('.item').hide();
+                        $(el_item_container).addClass('desktop-icons-hidden');
+                    }else{
+                        $(el_item_container).find('.item').show();
+                        $(el_item_container).removeClass('desktop-icons-hidden');
+                    }
+                }
+            }catch(err){
+                console.warn('Error applying hide_desktop_icons preference', err);
+            }
+
             if(options.fadeInItems)
                 $(el_item_container).animate({'opacity': '1'});
 


### PR DESCRIPTION
Description of Pull Request:

Adds a right‑click desktop toggle to hide or show icons. The boolean is persisted to user preferences (puter.kv) and enforced on desktop re‑renders so icon positions are preserved. Changes are broadcast via BroadcastChannel for immediate sync across tabs.


Resolves #3 

Before Screenshot:

<img width="1704" height="889" alt="Screenshot 2025-11-02 at 5 58 39 PM" src="https://github.com/user-attachments/assets/32b8e7db-1388-4ff6-b61c-f695a6724453" />

After Screenshots:

<img width="1709" height="891" alt="Screenshot 2025-11-02 at 5 59 58 PM" src="https://github.com/user-attachments/assets/4019abb7-6d37-48e3-8bea-3e844e738395" />

<img width="1708" height="892" alt="Screenshot 2025-11-02 at 6 00 17 PM" src="https://github.com/user-attachments/assets/7139330d-3c53-42ab-9650-d71c0a4f809b" />



Video Demo and Code Walkthrough:: https://www.loom.com/share/dc17e91862ca4713b6d1236cb256c120
