### PR TITLE
Feature/set desktop bg context menu

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -1184,6 +1184,53 @@ function UIItem(options){
                 });                
             }
             // -------------------------------------------
+            // Set as Desktop Background (images only)
+            // -------------------------------------------
+            try {
+                const ext = path.extname($(el_item).attr('data-path')).toLowerCase();
+                const image_exts = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'];
+                if(!is_trash && !is_trashed && image_exts.includes(ext)){
+                    menu_items.push({
+                        html: i18n('set_as_desktop_background'),
+                        onClick: async function(){
+                            try{
+                                // Request a signed read URL for this file and set it as desktop background
+                                const sig = await puter.fs.sign(window.host_app_uid ?? null, { uid: options.uid, action: 'read' });
+                                const url = sig?.read_url ?? sig?.url;
+                                if(url){
+                                    // Immediately update the UI
+                                    window.set_desktop_background({ url: url, fit: 'cover' });
+
+                                    // Persist the preference server-side
+                                    try{
+                                        $.ajax({
+                                            url: window.api_origin + "/set-desktop-bg",
+                                            type: 'POST',
+                                            data: JSON.stringify({ url: url, fit: 'cover' }),
+                                            async: true,
+                                            contentType: "application/json",
+                                            headers: {
+                                                "Authorization": "Bearer "+window.auth_token
+                                            },
+                                            statusCode: {
+                                                401: function () { window.logout(); }
+                                            },
+                                        })
+                                    }catch(e){
+                                        // non-fatal
+                                        console.warn('Failed to persist desktop background', e);
+                                    }
+                                }
+                            }catch(err){
+                                console.error('Failed to set desktop background', err);
+                            }
+                        }
+                    });
+                }
+            } catch (e) {
+                // ignore any error computing extension
+            }
+            // -------------------------------------------
             // Zip
             // -------------------------------------------
             if(!is_trash && !is_trashed && !$(el_item).attr('data-path').endsWith('.zip')){

--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -1196,7 +1196,23 @@ function UIItem(options){
                             try{
                                 // Request a signed read URL for this file and set it as desktop background
                                 const sig = await puter.fs.sign(window.host_app_uid ?? null, { uid: options.uid, action: 'read' });
-                                const url = sig?.read_url ?? sig?.url;
+                                // puter.fs.sign can return different shapes:
+                                // - a single signature object with read_url/readURL/url
+                                // - an object with `items` array containing signature objects
+                                // Normalize to pick the first available read URL.
+                                let url = undefined;
+                                try{
+                                    if(sig){
+                                        if(sig.items){
+                                            const first = Array.isArray(sig.items) ? sig.items[0] : sig.items;
+                                            url = first?.read_url ?? first?.readURL ?? first?.url ?? first?.readUrl;
+                                        } else {
+                                            url = sig?.read_url ?? sig?.readURL ?? sig?.url ?? sig?.readUrl;
+                                        }
+                                    }
+                                }catch(e){
+                                    console.warn('Unexpected signature shape', e, sig);
+                                }
                                 if(url){
                                     // Immediately update the UI
                                     window.set_desktop_background({ url: url, fit: 'cover' });

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -103,6 +103,7 @@ const en = {
         descending: 'Descending',
         desktop: 'Desktop',
         desktop_background_fit: "Fit",
+    set_as_desktop_background: 'Set as Desktop Background',
         developers: "Developers",
         dir_published_as_website: `%strong% has been published to:`,
         disable_2fa: 'Disable 2FA',


### PR DESCRIPTION
Description of Pull Request:

- Context menu integration: Added new menu item that appears when right-clicking on image files (PNG, JPG, GIF, WebP, BMP, SVG)
- Security: Uses signed URLs via puter.fs.sign() to securely access image files with proper permissions
- Immediate UI feedback: Updates desktop background instantly when selected for responsive user experience
- Persistence: Saves background preference to server via /set-desktop-bg endpoint so setting persists across sessions
- Smart filtering: Menu item only appears for valid image files that aren't in trash
- Error handling: Graceful degradation with try-catch blocks - UI updates even if server persistence fails
- Internationalization: Added translation key set_as_desktop_background to English locale

Technical Notes:


- Handles multiple API response formats from signature endpoint for robustness
- Uses async/await for network operations
- Non-blocking server persistence prevents UI freezing

Fixes #10 - Users can now set desktop backgrounds directly from file context menu

Before:

<img width="1574" height="889" alt="Screenshot 2025-11-09 at 9 22 15 PM" src="https://github.com/user-attachments/assets/003f3c0c-3025-4fa6-817a-7e06f071bf92" />


After:

<img width="1585" height="895" alt="Screenshot 2025-11-09 at 9 45 06 PM" src="https://github.com/user-attachments/assets/a68bb7a8-617c-453f-af68-2bb2e8f97524" />
<img width="1588" height="893" alt="Screenshot 2025-11-09 at 9 45 18 PM" src="https://github.com/user-attachments/assets/d25256cf-2c61-4e33-a0e8-0f3944afee1a" />


Video Demo and Code Walkthrough:

https://www.loom.com/share/357546dc567e4e83954ad52c5bff8853
