### PR TITLE
feat: add 'Duplicate' context menu item for files; add i18n key

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -1248,6 +1248,20 @@ function UIItem(options){
                 });
             }
             // -------------------------------------------
+            // Duplicate (creates a copy in the same folder)
+            // -------------------------------------------
+            if(!is_trashed && !is_trash && $(el_item).attr('data-is_dir') === '0' && $(el_item).attr('data-immutable') === '0'){
+                menu_items.push({
+                    html: i18n('duplicate'),
+                    onClick: function(){
+                        // Use existing copy helper to duplicate into same directory
+                        const src_path = $(el_item).attr('data-path');
+                        const dest_dir = path.dirname(src_path);
+                        window.copy_items([el_item], dest_dir);
+                    }
+                });
+            }
+            // -------------------------------------------
             // Paste Into Folder
             // -------------------------------------------
             if($(el_item).attr('data-is_dir') === '1' && !is_trashed && !is_trash){

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -77,6 +77,7 @@ const en = {
         contain: 'Contain',
         continue: "Continue",
         copy: 'Copy',
+        duplicate: 'Duplicate',
         copy_link: "Copy Link",
         copying: "Copying",
         copying_file: "Copying %%",


### PR DESCRIPTION
Description of Pull Request:

- Adds a "Duplicate" menu item to the file context menu that creates a copy of the file in the same directory with an automatically generated unique filename.

Changes

- Added "Duplicate" option to file context menu in UIItem.js (visible only for non-trashed, non-immutable files)
- Leverages existing copy_items() function by passing the parent directory as destination
- Automatic filename conflict resolution generates names like "document copy.txt", "document (1).txt", etc.
- Added English translation for "Duplicate" label in i18n/translations/en.js

Implementation Notes
This implementation reuses the existing copy logic rather than duplicating code. By calling window.copy_items() with the file's own directory as the destination, the built-in naming conflict resolution automatically handles duplicate filename generation.

Fixes #24 

Before Screenshot:

<img width="832" height="574" alt="Screenshot 2025-11-16 at 4 33 51 PM" src="https://github.com/user-attachments/assets/67c58d46-f1e5-4b16-ac88-5b36a992b225" />

After Screenshots:

<img width="798" height="448" alt="Screenshot 2025-11-16 at 4 51 50 PM" src="https://github.com/user-attachments/assets/354816a9-39a3-4a76-b5ee-af3e10f765ab" />
<img width="903" height="688" alt="Screenshot 2025-11-16 at 4 52 42 PM" src="https://github.com/user-attachments/assets/3efc1b1d-97f6-4ecb-a8af-fc7a601f9334" />
<img width="1045" height="778" alt="Screenshot 2025-11-16 at 4 52 34 PM" src="https://github.com/user-attachments/assets/77f83956-2173-4ecb-92d3-126a96e34929" />


Video Demo and Code Walkthrough: https://www.loom.com/share/3263667b36d140eaac31712f20257a3c