### PR TITLE
feat: show total size for selected items in explorer footer

### DIFF
--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -3336,7 +3336,22 @@ window.update_explorer_footer_selected_items_count = function(el_window){
     let item_count = $(el_window).find('.item-selected').length;
     if(item_count > 0){
         $(el_window).find('.explorer-footer-seperator, .explorer-footer-selected-items-count').show();
-        $(el_window).find('.explorer-footer .explorer-footer-selected-items-count').html(item_count + ` ${i18n('item')}` + (item_count == 0 || item_count > 1 ? `${i18n('plural_suffix')}` : '') + ` ${i18n('selected')}`);
+        // Calculate total size of selected non-directory items. Folders count towards the
+        // item count but are not included in the byte total (simplified behavior).
+        let total_bytes = 0;
+        $(el_window).find('.item-selected').each(function(){
+            const is_dir = $(this).attr('data-is_dir') === '1';
+            if(!is_dir){
+                const raw_size = $(this).attr('data-size');
+                const size_num = parseInt(raw_size) || 0;
+                total_bytes += size_num;
+            }
+        });
+
+        const size_display = window.byte_format(total_bytes);
+        $(el_window).find('.explorer-footer .explorer-footer-selected-items-count').html(
+            item_count + ` ${i18n('item')}` + (item_count == 0 || item_count > 1 ? `${i18n('plural_suffix')}` : '') + ` ${i18n('selected')}` + ` • ` + size_display
+        );
     }else{
         $(el_window).find('.explorer-footer-seperator, .explorer-footer-selected-items-count').hide();
     }


### PR DESCRIPTION
Description of Pull Request:


Added total file size display to the Explorer footer. When files are selected, the footer now shows both the item count and cumulative size (e.g., "3 items selected • 45.2 MB").


Updated `window.update_explorer_footer_selected_items_count` in UIWindow.js to:
- Sum the `data-size` attribute of all selected files (dynamic)
- Exclude folders from the size calculation (they still count toward the item total)
- Format the total using `window.byte_format` for human-readable output (B, KB, MB, GB)

Fixes #23 


Before Screenshot:
<img width="956" height="580" alt="Screenshot 2025-11-23 at 4 03 16 PM" src="https://github.com/user-attachments/assets/d8ceeec0-b3f8-4ca4-8240-644fd538cdb7" />


After Screenshots:

<img width="825" height="496" alt="Screenshot 2025-11-23 at 4 18 28 PM" src="https://github.com/user-attachments/assets/7c64d67e-a1e2-4304-97e9-3d8ddff52d16" />


<img width="1026" height="565" alt="Screenshot 2025-11-23 at 4 20 50 PM" src="https://github.com/user-attachments/assets/178d82b2-cc5f-4b22-9ce4-4ebe84416652" />







Video Demo and Code Walkthrough: https://www.loom.com/share/ff8537ae881143c68b865a0907832b55