### PR TITLE
Feature/desktop link shortcuts

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -1264,22 +1264,55 @@ async function UIDesktop(options){
     })  
 
     // Paste handler: if clipboard contains a URL, create a .weblink on the desktop
-    $(el_desktop).on('paste', async function(e){
+    $(document).on('paste', async function(e){
+        // Only handle paste when not inside an input/textarea
+        const $target = $(e.target);
+        if($target.is('input, textarea, [contenteditable="true"]')){
+            return; // Let normal paste behavior happen
+        }
+        
+        // Check if we're pasting on the desktop
+        const $desktop = $('.desktop.item-container');
+        if(!$desktop.length) return;
+        
+        // Don't handle paste if we're focused inside a window (unless it's a desktop window)
+        const $activeWindow = $(document.activeElement).closest('.window');
+        if($activeWindow.length > 0){
+            // Allow if the window is showing the desktop path
+            const windowPath = $activeWindow.attr('data-path');
+            if(windowPath && windowPath !== window.desktop_path){
+                return;
+            }
+        }
+    
         try{
-            // try clipboardData first
             const clipboardEvent = e.originalEvent || e;
             let text = '';
+            
+            // Try clipboardData first (synchronous, more reliable)
             if(clipboardEvent.clipboardData && clipboardEvent.clipboardData.getData){
-                text = clipboardEvent.clipboardData.getData('text') || '';
+                text = clipboardEvent.clipboardData.getData('text/plain') || 
+                       clipboardEvent.clipboardData.getData('text') || '';
             }
+            
+            // Fallback to async clipboard API
             if(!text && navigator.clipboard && navigator.clipboard.readText){
-                text = await navigator.clipboard.readText().catch(()=>'');
+                try {
+                    text = await navigator.clipboard.readText();
+                } catch(clipErr) {
+                    console.log('Clipboard read failed:', clipErr);
+                }
             }
+            
             text = (text || '').trim();
             if(!text) return;
-
+    
+            // Check if it's a URL
             if(/^https?:\/\//i.test(text)){
-                // derive filename from hostname
+                e.preventDefault();
+                e.stopPropagation();
+                
+                // Derive filename from hostname
                 let filename;
                 try{
                     const u = new URL(text);
@@ -1287,11 +1320,16 @@ async function UIDesktop(options){
                 }catch(err){
                     filename = 'New Link.weblink';
                 }
-
-                window.create_file({dirname: window.desktop_path, append_to_element: el_desktop, name: filename, content: text});
+    
+                window.create_file({
+                    dirname: window.desktop_path, 
+                    append_to_element: $desktop.get(0), 
+                    name: filename, 
+                    content: text
+                });
             }
         }catch(err){
-            console.error(err);
+            console.error('Paste handler error:', err);
         }
     });
 

--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -1263,6 +1263,38 @@ async function UIDesktop(options){
         $('.window-menubar-global').hide();
     })  
 
+    // Paste handler: if clipboard contains a URL, create a .weblink on the desktop
+    $(el_desktop).on('paste', async function(e){
+        try{
+            // try clipboardData first
+            const clipboardEvent = e.originalEvent || e;
+            let text = '';
+            if(clipboardEvent.clipboardData && clipboardEvent.clipboardData.getData){
+                text = clipboardEvent.clipboardData.getData('text') || '';
+            }
+            if(!text && navigator.clipboard && navigator.clipboard.readText){
+                text = await navigator.clipboard.readText().catch(()=>'');
+            }
+            text = (text || '').trim();
+            if(!text) return;
+
+            if(/^https?:\/\//i.test(text)){
+                // derive filename from hostname
+                let filename;
+                try{
+                    const u = new URL(text);
+                    filename = `${u.hostname}.weblink`;
+                }catch(err){
+                    filename = 'New Link.weblink';
+                }
+
+                window.create_file({dirname: window.desktop_path, append_to_element: el_desktop, name: filename, content: text});
+            }
+        }catch(err){
+            console.error(err);
+        }
+    });
+
     function display_ct() {
         var x = new Date()
         var ampm = x.getHours( ) >= 12 ? ' PM' : ' AM';

--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -546,14 +546,27 @@ function UIItem(options){
             if(!options.is_dir && item_path.toLowerCase().endsWith('.weblink')){
                 try{
                     const content = await puter.fs.read(item_path);
-                    const url = (typeof content === 'string') ? content.trim() : (content?.toString?.() ?? '').trim();
+        
+        // puter.fs.read() returns a Blob, so we need to convert it to text
+                    let url = '';
+                    if(content instanceof Blob){
+                        url = (await content.text()).trim();
+                    } else if(typeof content === 'string'){
+                        url = content.trim();
+                    } else if(content && typeof content.text === 'function'){
+                        url = (await content.text()).trim();
+                    } else {
+                        url = String(content || '').trim();
+                    }
+        
                     if(url && /^https?:\/\//i.test(url)){
                         window.open(url, '_blank', 'noopener,noreferrer');
                     }else{
                         await UIAlert(i18n('invalid_url') || 'Invalid URL');
                     }
                 }catch(err){
-                    await UIAlert(err.message ?? err);
+                    console.error('Error opening weblink:', err);
+                    await UIAlert(err.message ?? String(err));
                 }
                 return;
             }

--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -540,9 +540,26 @@ function UIItem(options){
 
             if($(e.target).hasClass('item-name-editor'))
                 return false;
-    
+
+            // If this is a web link shortcut file, open its URL directly
+            const item_path = $(el_item).attr('data-path') ?? '';
+            if(!options.is_dir && item_path.toLowerCase().endsWith('.weblink')){
+                try{
+                    const content = await puter.fs.read(item_path);
+                    const url = (typeof content === 'string') ? content.trim() : (content?.toString?.() ?? '').trim();
+                    if(url && /^https?:\/\//i.test(url)){
+                        window.open(url, '_blank', 'noopener,noreferrer');
+                    }else{
+                        await UIAlert(i18n('invalid_url') || 'Invalid URL');
+                    }
+                }catch(err){
+                    await UIAlert(err.message ?? err);
+                }
+                return;
+            }
+
             open_item({
-                item: el_item, 
+                item: el_item,
                 new_window: e.metaKey || e.ctrlKey,
             });
         });

--- a/src/gui/src/helpers/item_icon.js
+++ b/src/gui/src/helpers/item_icon.js
@@ -114,6 +114,10 @@ const item_icon = async (fsentry)=>{
     else if(fsentry.name.toLowerCase().endsWith('.docx')){
         return {image: window.icons['file-docx.svg'], type: 'icon'};
     }
+    // *.weblink (web link shortcuts)
+    else if(fsentry.name.toLowerCase().endsWith('.weblink')){
+        return {image: window.icons['link.svg'], type: 'icon'};
+    }
     // *.exe
     else if(fsentry.name.toLowerCase().endsWith('.exe')){
         return {image: window.icons['file-exe.svg'], type: 'icon'};

--- a/src/gui/src/helpers/new_context_menu_item.js
+++ b/src/gui/src/helpers/new_context_menu_item.js
@@ -42,7 +42,7 @@ const new_context_menu_item = function(dirname, append_to_element){
         },
         // New Link
         {
-            html: i18n('new_link') || 'New Link',
+            html: 'New Link',
             icon: `<img src="${html_encode(window.icons['link.svg'])}" class="ctx-item-icon">`,
             onClick: async function() {
                 const url = await UIPrompt({ message: 'Enter URL', placeholder: 'http:// or https://' });

--- a/src/gui/src/helpers/new_context_menu_item.js
+++ b/src/gui/src/helpers/new_context_menu_item.js
@@ -26,6 +26,9 @@
  * @returns {Object} The context menu item object
  */
 
+import UIPrompt from '../UI/UIPrompt.js';
+import UIAlert from '../UI/UIAlert.js';
+
 const new_context_menu_item = function(dirname, append_to_element){
     
     const baseItems = [
@@ -36,6 +39,29 @@ const new_context_menu_item = function(dirname, append_to_element){
             onClick: function() {
                 window.create_folder(dirname, append_to_element);
             },
+        },
+        // New Link
+        {
+            html: i18n('new_link') || 'New Link',
+            icon: `<img src="${html_encode(window.icons['link.svg'])}" class="ctx-item-icon">`,
+            onClick: async function() {
+                const url = await UIPrompt({ message: i18n('enter_url') || 'Enter URL', placeholder: 'https://example.com' });
+                if(!url) return;
+                if(!/^https?:\/\//i.test(url)){
+                    await UIAlert(i18n('url_must_start_with_http') || 'URL must start with http:// or https://');
+                    return;
+                }
+
+                let filename;
+                try{
+                    const u = new URL(url);
+                    filename = `${u.hostname}.weblink`;
+                }catch(e){
+                    filename = `New Link.weblink`;
+                }
+
+                window.create_file({dirname: dirname, append_to_element: append_to_element, name: filename, content: url});
+            }
         },
         // divider
         '-',

--- a/src/gui/src/helpers/new_context_menu_item.js
+++ b/src/gui/src/helpers/new_context_menu_item.js
@@ -45,7 +45,7 @@ const new_context_menu_item = function(dirname, append_to_element){
             html: i18n('new_link') || 'New Link',
             icon: `<img src="${html_encode(window.icons['link.svg'])}" class="ctx-item-icon">`,
             onClick: async function() {
-                const url = await UIPrompt({ message: i18n('enter_url') || 'Enter URL', placeholder: 'https://example.com' });
+                const url = await UIPrompt({ message: 'Enter URL', placeholder: 'http:// or https://' });
                 if(!url) return;
                 if(!/^https?:\/\//i.test(url)){
                     await UIAlert(i18n('url_must_start_with_http') || 'URL must start with http:// or https://');


### PR DESCRIPTION
Description of Pull Request:

Adds the ability to create .weblink shortcut files that store URLs and open them in a new browser tab when double-clicked.
Changes

- item_icon.js — Display link icon for .weblink files
- new_context_menu_item.js — Add "New Link" option to right-click menu with URL validation
- UIItem.js — Handle double-click to open URL in new tab
- UIDesktop.js — Auto-create .weblink file when pasting a URL on desktop

Features

1. Right-click → "New Link" prompts for URL (validates http/https)
2. Paste a URL on desktop to auto-create shortcut
3. Double-click .weblink file opens URL in new tab
4. Filenames derived from domain (e.g., github.com.weblink)


Fixes #11 


Before Screenshot:

<img width="1491" height="728" alt="Screenshot 2025-11-30 at 7 00 13 PM" src="https://github.com/user-attachments/assets/2e5febaf-0942-4f3c-986d-a6ef6566500c" />


After Screenshots:

<img width="1609" height="677" alt="Screenshot 2025-11-30 at 10 51 31 PM" src="https://github.com/user-attachments/assets/a4f3aa81-b31f-41bd-a1a4-30e0414d77a5" />

<img width="1015" height="386" alt="Screenshot 2025-11-30 at 11 01 02 PM" src="https://github.com/user-attachments/assets/34d538d4-14cf-4ac4-906d-a0d8fe221cbd" />




Video Demo and Code Walkthrough Part 1: https://www.loom.com/share/bcb3782557454548a3f9801aa0094aa0

Video Demo and Code Walkthrough Part 2: https://www.loom.com/share/c8be6fe492d64469945dedbcd7ff826c