### PR TITLE
fix: prevent window focus change when closing or minimizing backgroun…

### DIFF
--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -1231,6 +1231,11 @@ window.initgui = async function(options){
             // is using the popover API to show a popover, the popover will be closed if the window is activated
             if($(e.target).hasClass('popover') || $(e.target).parents('.popover').length > 0)
                 return;
+            // if close, minimize, or scale button clicked, don't activate window - just let the button handler execute
+            if($(e.target).hasClass('window-close-btn') || $(e.target).closest('.window-close-btn').length > 0 ||
+               $(e.target).hasClass('window-minimize-btn') || $(e.target).closest('.window-minimize-btn').length > 0 ||
+               $(e.target).hasClass('window-scale-btn') || $(e.target).closest('.window-scale-btn').length > 0)
+                return;
             $(window.mouseover_window).focusWindow(e);
         }
     })


### PR DESCRIPTION
Description of Pull Request:

- Skip focusWindow() call when user clicks close, minimize, or scale buttons
- Allows users to close/minimize background windows without bringing them to foreground
- Clicking other window areas still brings window to front as expected
- Fixes jarring UX when closing partially obscured windows


Fixes #29

Before Screenshot (the window behind would jump to the front before closing/minimizing):

<img width="880" height="578" alt="Screenshot 2025-12-07 at 11 36 27 PM" src="https://github.com/user-attachments/assets/b6aa2ad1-d650-4e03-b9a9-5935012ad976" />


After Screenshot (the window behind closes normally without jumping):


<img width="950" height="528" alt="Screenshot 2025-12-07 at 11 37 11 PM" src="https://github.com/user-attachments/assets/90c5a4f2-9e17-414b-b888-b23186feb262" />


Video Demo and Code Walkthrough: https://www.loom.com/share/d01389b5384c482cadf0d55099b5ee41
